### PR TITLE
Match Supabase API key env names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,7 @@
 # Update these with your Supabase details from your project settings > API keys
 # https://supabase.com/dashboard/project/<project-ref>/settings/api-keys
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
-# Supabase's generated setup snippet may use
-# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY. Copy that value into
-# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY below for this app.
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-or-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # x402 / Circle Nanopayments

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Update these with your Supabase details from your project settings > API keys
-# https://supabase.com/dashboard/project/qxqkfkzaylahpvhaojbt/settings/api-keys
+# https://supabase.com/dashboard/project/<project-ref>/settings/api-keys
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
 # Supabase's generated setup snippet may use
 # NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY. Copy that value into

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
-# Update these with your Supabase details from your project settings > API
-# https://app.supabase.com/project/_/settings/api
+# Update these with your Supabase details from your project settings > API keys
+# https://supabase.com/dashboard/project/qxqkfkzaylahpvhaojbt/settings/api-keys
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
+# Supabase's generated setup snippet may use
+# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY. Copy that value into
+# NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY below for this app.
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Copy `.env.example` to `.env.local` and fill in the required values:
 ```bash
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-or-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # x402 / Circle Nanopayments
@@ -161,7 +161,7 @@ BUYER_PRIVATE_KEY=0xYourBuyerPrivateKey
 | Variable | Scope | Purpose |
 | --- | --- | --- |
 | `NEXT_PUBLIC_SUPABASE_URL` | Public | Supabase project URL. |
-| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Public | Supabase anonymous / publishable key. |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` | Public | Supabase anonymous / publishable key. |
 | `SUPABASE_SERVICE_ROLE_KEY` | Server-side | Supabase service-role key, used to record payment events and withdrawals. |
 | `SELLER_ADDRESS` | Server-side | EVM wallet address for receiving USDC payments. |
 | `SELLER_PRIVATE_KEY` | Server-side | Seller wallet private key, used for Gateway balance queries and withdrawals. |

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -21,6 +21,6 @@ import { createBrowserClient } from "@supabase/ssr";
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
   );
 }

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -26,7 +26,7 @@ export async function updateSession(request: NextRequest) {
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
     {
       cookies: {
         getAll() {

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -29,7 +29,7 @@ export async function createClient() {
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
## Summary
- rename the repo env var to `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` to match Supabase's generated setup snippet
- update `.env.example` to point to the `settings/api-keys` page
- update README and Supabase client helpers to use the renamed env var consistently

## Why
The repo previously documented and read `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, while Supabase's generated setup flow uses `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`. Renaming the repo variable removes that mismatch and makes the onboarding path line up with what developers copy from Supabase.