### PR TITLE
Clarify generate-wallets next steps

### DIFF
--- a/generate-wallets.mts
+++ b/generate-wallets.mts
@@ -63,7 +63,11 @@ ${bold("Next steps:")}
 
      Paste this address: ${cyan(buyer.address)}
 
-  ${dim("2.")} Start the dev server:        ${cyan("npm run dev")}
-  ${dim("3.")} Run payment agents:          ${cyan("npm run agent")}
+  ${dim("2.")} Set up Supabase before starting the app.
+     Complete the local or remote Supabase steps in the README and fill in the
+     required Supabase values in ${cyan(".env.local")}.
+
+  ${dim("3.")} Start the dev server:        ${cyan("npm run dev")}
+  ${dim("4.")} Run payment agents:          ${cyan("npm run agent")}
      Run as many in parallel as you like — each spawns its own ephemeral wallet.
 `);


### PR DESCRIPTION
## Summary
- update the `generate-wallets` script output to tell developers to complete Supabase setup before starting the app
- keep the funded-wallet reminder first, then point to the README for the local or remote Supabase path
- move `npm run dev` and `npm run agent` to later steps so the order matches the real setup flow

## Why
The current "Next steps" output suggests starting the dev server and payment agent immediately after generating wallets. In practice, developers still need to complete Supabase setup and fill in the required Supabase env vars before the app and agent can run successfully.