### PR TITLE
Attach Haia Trace capture to seller and buyer x402 lifecycles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+node_modules
+.next
+out
+build
+coverage
+npm-debug.log*
+.env
+.env.*
+.DS_Store
+*.pem
+*.tsbuildinfo
+Dockerfile
+.dockerignore
+README.md

--- a/.env.ci
+++ b/.env.ci
@@ -5,5 +5,5 @@
 # OPENAI_API_KEY); those stay runtime-only and are injected at `docker run`.
 #
 # Replace the values below with your real Supabase project values.
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
+NEXT_PUBLIC_SUPABASE_URL=https://rqfqcvuefgylucvhthtn.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_en2RJRE6gbA15jMBRUvCQA_4hwn4E3g

--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,9 @@
+# Build-time env for CI (safe to commit).
+#
+# ONLY put NEXT_PUBLIC_* values here — they are compiled into the browser bundle
+# and are public by design. NEVER add secrets (service-role key, private keys,
+# OPENAI_API_KEY); those stay runtime-only and are injected at `docker run`.
+#
+# Replace the values below with your real Supabase project values.
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -23,7 +23,7 @@ jobs:
       contents: read
       packages: write # push to GHCR with GITHUB_TOKEN
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [master]
 
+# Never let two deploys of the same branch overlap.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -45,3 +50,45 @@ jobs:
           build-args: |
             NEXT_PUBLIC_SUPABASE_URL=${{ env.NEXT_PUBLIC_SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+
+  # Deploy the Helm chart straight from the repo checkout (no chart registry)
+  # to the dev GKE cluster, pinning the image to this commit's tag.
+  deploy:
+    needs: docker
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write # Workload Identity Federation to GCP
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GHA_SA }}
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          project_id: ${{ vars.GKE_PROJECT }}
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ vars.GKE_LOCATION }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v4.2.0
+
+      # Deploy :latest (per values-dev.yaml). deployRevision changes the pod
+      # spec each commit so Helm rolls the pods; with pullPolicy: Always the
+      # rollout then pulls the freshly pushed :latest image.
+      - name: Helm upgrade --install
+        run: |
+          helm upgrade --install arc-nanopayments deploy/helm \
+            -f deploy/helm/values-dev.yaml \
+            --set deployRevision=${{ github.sha }} \
+            --set httpRoute.hostnames[0]=${{ vars.DEV_HOST }} \
+            -n ${{ vars.DEPLOY_NAMESPACE }} \
+            --wait --timeout 10m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  docker:
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push to GHCR with GITHUB_TOKEN
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Load committed, public build-time values (NEXT_PUBLIC_*) into the job env.
+      # .dockerignore strips .env.ci from the build context, so we feed it as
+      # build-args here rather than COPYing it inside the Dockerfile.
+      - name: Load build-time env from .env.ci
+        run: grep -E '^[A-Z].*=' .env.ci >> "$GITHUB_ENV"
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/haia-finance/arc-nanopayments:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=${{ env.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A demo of gasless USDC nanopayments on Arc Testnet using Circle's x402 batching (Gateway). A **Next.js App Router** app is the **seller** — it exposes x402-protected `/api/premium/*` endpoints and a `/dashboard` for monitoring payments and withdrawing earnings. A standalone script (`agent.mts`) is the **buyer** — it deposits USDC into Gateway and pays those endpoints in a loop. Settlement is batched offchain by Circle Gateway so sub-cent payments are viable.
+
+## Commands
+
+```bash
+npm run dev              # dev server at http://localhost:3000
+npm run build            # production build (output: standalone)
+npm start                # run the built app
+npm run lint             # eslint
+
+npm run generate-wallets # create seller + buyer wallets, writes keys into .env.local
+npm run agent            # run the buyer (pays the premium endpoints in a loop)
+npm run agent -- --limit 0.5   # cap USDC spend; pauses and prompts for more when hit
+```
+
+There is no test suite. `agent.mts` and `generate-wallets.mts` run via `node --experimental-transform-types` (TS executed directly, no build step) and load `.env.local` via `--env-file`.
+
+### Database (Supabase)
+
+Two tables: `payment_events` (append-only settled-payment log) and `withdrawals` (withdrawal audit trail), both public-read with service-role writes, and both in the realtime publication. Migrations live in `supabase/migrations/`.
+
+```bash
+npx supabase db push     # apply migrations to the linked cloud project
+```
+
+Note: this project runs against **cloud Supabase**; the local Docker/`supabase start` path is documented in the README but currently broken in this environment.
+
+## Architecture
+
+**Payment lifecycle (seller side)** — `lib/x402.ts` is the core. A single `createGatewayMiddleware` instance (Circle's `@circle-fin/x402-batching/server`) is shared by every paywalled route. `withGateway(handler, price, endpoint)` wraps a route handler: it adapts the SDK's Express-style `(req, res, next)` middleware to a Next.js App Router handler, driving the full x402 flow (402 challenge → verify → settle → run handler via `next()`). Each premium route (`app/api/premium/*/route.ts`) is just a plain handler exported through `withGateway`.
+
+**Gateway lifecycle hooks are the integration surface.** In `lib/x402.ts` the `onBeforeVerify` / `onAfterSettle` / `onSettleFailure` hooks are where settled payments get persisted to `payment_events` — and are the designated attach point for Haia Trace spans (HAD-336). The buyer side (`agent.mts`) has the mirror hooks: `onBeforePaymentCreation` / `onAfterPaymentCreation` / `onPaymentResponse`. Both sets currently just `console.log("[haia-trace] ...")`; swap the bodies for real spans when the SDK lands. Don't delete these hooks.
+
+**Buyer (`agent.mts`)** — despite the README describing a LangChain agent, the actual buyer is a throughput script: it generates an **ephemeral wallet** each run, funds it from `BUYER_PRIVATE_KEY` (native USDC for gas + ERC-20 USDC), deposits into Gateway, then pays the 4 endpoints round-robin at ~1 tx/sec. It auto-redeposits when the Gateway balance drops below the threshold, and uses `withNonceRetry` to survive nonce collisions when multiple agents fund from the same wallet concurrently. (The `@langchain/*` and `deepagents` deps are present but not used by `agent.mts`.)
+
+**Withdrawals** — `app/api/gateway/withdraw/route.ts` uses `SELLER_PRIVATE_KEY` to withdraw Gateway USDC to any supported testnet chain (cross-chain via CCTP). It pre-checks native gas on source and destination chains, records a `submitted` row, then updates to `confirmed`/`failed`. Balance display is `app/api/gateway/balance/route.ts`.
+
+**Auth** — demo-only. `app/actions.ts` checks a hardcoded `admin@example.com` / `123456` and sets an httpOnly `session=authenticated` cookie. `proxy.ts` (Next.js 16's renamed middleware — *not* `middleware.ts`) redirects based on that cookie: signed-in users away from `/`, signed-out users away from `/dashboard`.
+
+**Dashboard** — client components under `components/dashboard/` read live data through hooks `hooks/use-transactions.ts` (`payment_events`) and `hooks/use-withdrawals.ts`, each opening a Supabase realtime channel. The hooks subscribe first and fetch initial rows only after `SUBSCRIBED`, then dedupe — done deliberately so no event is lost in the fetch/subscribe gap.
+
+**Supabase clients** — `lib/supabase/server.ts` (SSR, cookie-based, create per-request — never a global), `lib/supabase/client.ts` (browser), `lib/supabase/proxy.ts`. Server-side payment/withdrawal writes use the service-role key via a plain `createClient` in the route/lib files.
+
+## Key facts & conventions
+
+- **Network**: Arc Testnet, `eip155:5042002`. USDC is `0x3600...0000`. Facilitator: `https://gateway-api-testnet.circle.com`. Arc gas is paid in USDC with **18 decimals** (payment amounts are 6-decimal USDC — mind the difference).
+- **`NEXT_PUBLIC_*` env vars are inlined at build time** — they must be present during `npm run build` / `docker build`, not just at runtime. Server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `SELLER_PRIVATE_KEY`, `SELLER_ADDRESS`) are runtime-only; the Dockerfile passes build-stage placeholders just to satisfy import-time client construction during page-data collection.
+- Some modules construct Supabase/Gateway clients at **import time**, so builds fail without those placeholder envs present.
+- **Docker**: multi-stage (`deps` → `builder` → `runner`), Next.js `output: "standalone"`, runs as non-root `nextjs` under `tini` (PID 1 signal handling / zombie reaping).
+- UI is shadcn/ui (new-york style, `components/ui/`) + Tailwind v4 + lucide icons. Path alias `@/*`. All source files carry the Apache-2.0 Circle copyright header.
+- Prices are dollar strings (`"$0.001"`) passed to `withGateway`; the `endpoint` arg is echoed back as `resource.url` and used as the `payment_events.endpoint` label.
+
+## Git workflow
+
+Commit straight to `master`, no feature branches. Push only on explicit approval.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci
 
+# ---------- prod-deps: production node_modules for the agent runtime ----------
+FROM node:22-alpine AS prod-deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
+
 # ---------- builder: compile the Next.js app ----------
 FROM node:22-alpine AS builder
 WORKDIR /app
@@ -49,6 +56,14 @@ RUN apk add --no-cache tini libc6-compat \
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# Agent CLI: ship the script and a full production node_modules so
+#   `node --experimental-transform-types agent.mts` works from this image.
+# This node_modules is a superset of the standalone trace (which only includes
+# the @circle-fin/x402-batching/server subpath used by the app), so it also
+# satisfies the agent's /client + viem/* subpaths while keeping server.js working.
+COPY --from=prod-deps --chown=nextjs:nodejs /app/node_modules ./node_modules
+COPY --from=builder --chown=nextjs:nodejs /app/agent.mts ./agent.mts
 
 USER nextjs
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1
+
+# ---------- deps: install node_modules from lockfile ----------
+FROM node:22-alpine AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+# ---------- builder: compile the Next.js app ----------
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# NEXT_PUBLIC_* values are inlined into the client bundle at build time,
+# so they must be present here, not only at runtime.
+# Defaults keep a plain `docker build .` from crashing at import-time client
+# construction; real values come via --build-arg.
+ARG NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co
+ARG NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=placeholder
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Some modules instantiate the Supabase/gateway clients at import time, which
+# Next evaluates while collecting page data. These placeholders only satisfy that
+# build step (they stay in this stage, never the final image); real server-side
+# secrets are injected at runtime via the container env.
+ENV SUPABASE_SERVICE_ROLE_KEY=build-placeholder
+ENV SELLER_ADDRESS=0x0000000000000000000000000000000000000000
+
+RUN npm run build
+
+# ---------- runner: minimal standalone server ----------
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# tini reaps zombies and forwards signals so SIGTERM triggers a clean shutdown
+# (PID 1 has no default signal handlers); libc6-compat covers any glibc addon.
+RUN apk add --no-cache tini libc6-compat \
+  && addgroup -g 1001 -S nodejs \
+  && adduser -u 1001 -S nextjs -G nodejs
+
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "server.js"]

--- a/agent.mts
+++ b/agent.mts
@@ -161,6 +161,28 @@ const gateway = new GatewayClient({
   privateKey: ephemeralKey,
 });
 
+// Buyer-side lifecycle hooks: the integration surface for Haia Trace (HAD-336
+// phase 4). The payment span attaches across these three; for now they log.
+gateway
+  .onBeforePaymentCreation(async (ctx) => {
+    const amount = Number(ctx.selectedRequirements.amount) / 1e6;
+    console.log(
+      `[haia-trace] paying ${amount} USDC for ${ctx.paymentRequired.resource?.url ?? "resource"}`,
+    );
+  })
+  .onAfterPaymentCreation(async (ctx) => {
+    console.log(
+      `[haia-trace] signed ${ctx.paymentPayload.resource?.url ?? "resource"}`,
+    );
+  })
+  .onPaymentResponse(async (ctx) => {
+    if (ctx.settleResponse?.transaction) {
+      console.log(
+        `[haia-trace] settled tx ${ctx.settleResponse.transaction.slice(0, 10)}...`,
+      );
+    }
+  });
+
 let index = 0;
 let inFlight = 0;
 let redepositing = false;

--- a/agent.mts
+++ b/agent.mts
@@ -70,10 +70,11 @@ if (!funderKey) {
 }
 
 const ARC_TESTNET_USDC = "0x3600000000000000000000000000000000000000" as const;
-const ARC_TESTNET_RPC = "https://rpc.testnet.arc.network";
+const ARC_TESTNET_RPC = "https://rpc.blockdaemon.testnet.arc.network";
 
 const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000";
 const DEPOSIT_AMOUNT = process.env.DEPOSIT_AMOUNT ?? "1";
+const PAYMENT_INTERVAL_MS = Number(process.env.PAYMENT_INTERVAL_MS ?? 600_000);
 // Amount of native USDC to send for gas (Arc testnet gas = USDC with 18 decimals)
 const GAS_FUND_AMOUNT = parseEther("0.01");
 
@@ -159,6 +160,7 @@ console.log(`  USDC transferred (${usdcTxHash.slice(0, 10)}...)`);
 const gateway = new GatewayClient({
   chain: "arcTestnet",
   privateKey: ephemeralKey,
+  rpcUrl: ARC_TESTNET_RPC,
 });
 
 // Buyer-side lifecycle hooks: the integration surface for Haia Trace (HAD-336
@@ -246,7 +248,7 @@ async function checkAndRedeposit() {
 await depositToGateway();
 
 console.log(
-  `\nTarget: 1 transaction/second across ${endpoints.length} endpoints\n`,
+  `\nTarget: 1 transaction every ${PAYMENT_INTERVAL_MS}ms across ${endpoints.length} endpoints\n`,
 );
 
 // Check balance every 30 seconds and redeposit if low.
@@ -312,7 +314,7 @@ function startPaymentLoop() {
           `#${index} ${ep.url.split("/").pop()} FAILED (${ms}ms): ${err.message} [in-flight: ${inFlight}]`,
         );
       });
-  }, 1000);
+  }, PAYMENT_INTERVAL_MS);
 }
 
 startPaymentLoop();

--- a/agent.mts
+++ b/agent.mts
@@ -74,7 +74,16 @@ const ARC_TESTNET_RPC = "https://rpc.blockdaemon.testnet.arc.network";
 
 const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000";
 const DEPOSIT_AMOUNT = process.env.DEPOSIT_AMOUNT ?? "1";
-const PAYMENT_INTERVAL_MS = Number(process.env.PAYMENT_INTERVAL_MS ?? 600_000);
+const PAYMENT_INTERVAL_MS = (() => {
+  const raw = process.env.PAYMENT_INTERVAL_MS;
+  if (raw === undefined) return 600_000;
+  const ms = Number(raw);
+  if (!Number.isFinite(ms) || ms <= 0) {
+    console.error(`PAYMENT_INTERVAL_MS must be a positive number of ms, got "${raw}"`);
+    process.exit(1);
+  }
+  return ms;
+})();
 // Amount of native USDC to send for gas (Arc testnet gas = USDC with 18 decimals)
 const GAS_FUND_AMOUNT = parseEther("0.01");
 

--- a/app/api/gateway/balance/route.ts
+++ b/app/api/gateway/balance/route.ts
@@ -21,7 +21,7 @@ import { createPublicClient, http, formatUnits, erc20Abi } from "viem";
 
 const GATEWAY_API = "https://gateway-api-testnet.circle.com/v1/balances";
 const ARC_TESTNET_DOMAIN = 26;
-const ARC_TESTNET_RPC = "https://rpc.testnet.arc.network";
+const ARC_TESTNET_RPC = "https://rpc.blockdaemon.testnet.arc.network";
 const ARC_TESTNET_USDC = "0x3600000000000000000000000000000000000000" as const;
 
 const publicClient = createPublicClient({

--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,10 @@
+# Patterns to ignore when packaging Helm charts.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.bak
+*.swp
+*.orig
+.idea/
+.vscode/

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: arc-nanopayments
+description: |
+  Arc nanopayments demo — a Next.js x402 "seller" app plus a payment-agent "buyer",
+  both running from a single container image.
+type: application
+version: "0.1.0"
+# Default container image tag. Override with image.tag for immutable deploys.
+appVersion: "latest"
+kubeVersion: ">=1.27.0-0"
+home: https://github.com/Haia-Finance/arc-nanopayments
+sources:
+  - https://github.com/Haia-Finance/arc-nanopayments
+maintainers:
+  - name: Haia
+    url: https://haia.app
+keywords:
+  - x402
+  - nanopayments
+  - circle
+  - arc

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -1,0 +1,47 @@
+arc-nanopayments {{ .Chart.AppVersion }} deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Components:
+  seller (Next.js app)   -> Deployment/Service {{ include "arc-nanopayments.fullname" . }}-seller
+  buyer  (payment agent) -> Deployment {{ include "arc-nanopayments.fullname" . }}-buyer
+  buyer BASE_URL         -> {{ include "arc-nanopayments.sellerBaseUrl" . }}
+
+{{- if .Values.httpRoute.enabled }}
+
+Seller exposed via Gateway API HTTPRoute {{ include "arc-nanopayments.fullname" . }}-seller
+  Hostnames: {{ if .Values.httpRoute.hostnames }}{{ join ", " .Values.httpRoute.hostnames }}{{ else }}(none set — add httpRoute.hostnames){{ end }}
+  Attached to Gateway(s): {{ range .Values.httpRoute.parentRefs }}{{ .name }} {{ end }}
+  Inspect route + programmed status:
+    kubectl -n {{ .Release.Namespace }} get httproute {{ include "arc-nanopayments.fullname" . }}-seller
+  TLS and the load-balancer IP are owned by the referenced Gateway (not this chart).
+  Point DNS for the hostname(s) above at the Gateway's address.
+{{- end }}
+
+Prerequisites this chart does NOT create — set these up once:
+{{- if .Values.image.pullSecrets }}
+
+  1. GHCR image pull secret(s) {{ range .Values.image.pullSecrets }}"{{ .name }}" {{ end }}(package is private):
+       kubectl -n {{ .Release.Namespace }} create secret docker-registry <name> \
+         --docker-server=ghcr.io \
+         --docker-username=<github-user> \
+         --docker-password=<PAT with read:packages>
+{{- end }}
+
+{{- if .Values.externalSecret.enabled }}
+
+  2. External Secrets Operator installed, with a "{{ .Values.externalSecret.secretStoreRef.name }}"
+     {{ .Values.externalSecret.secretStoreRef.kind }} backed by GCP Secret Manager.
+
+  3. A single GCP Secret Manager entry (JSON), synced into the shared Secret
+     "{{ include "arc-nanopayments.externalSecretName" . }}" and consumed by both roles:
+     {{- range .Values.externalSecret.dataFrom }}{{ with .extract }}
+       {{ .key }}  -> keys: SUPABASE_SERVICE_ROLE_KEY, SELLER_PRIVATE_KEY, BUYER_PRIVATE_KEY
+     {{- end }}{{- end }}
+
+     Verify sync:
+       kubectl -n {{ .Release.Namespace }} get externalsecret
+{{- end }}
+{{- if .Values.httpRoute.enabled }}
+
+  4. An existing Gateway (gateway.networking.k8s.io) for the HTTPRoute to attach to,
+     referenced via httpRoute.parentRefs. The Gateway owns the TLS cert and public IP.
+{{- end }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,110 @@
+{{/*
+Chart name (respects nameOverride).
+*/}}
+{{- define "arc-nanopayments.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name (respects fullnameOverride / nameOverride).
+*/}}
+{{- define "arc-nanopayments.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name and version, for the helm.sh/chart label.
+*/}}
+{{- define "arc-nanopayments.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "arc-nanopayments.labels" -}}
+helm.sh/chart: {{ include "arc-nanopayments.chart" . }}
+{{ include "arc-nanopayments.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: arc-nanopayments
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "arc-nanopayments.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "arc-nanopayments.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Component-scoped labels. Call with (dict "ctx" . "component" "seller").
+*/}}
+{{- define "arc-nanopayments.componentLabels" -}}
+{{ include "arc-nanopayments.labels" .ctx }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Component-scoped selector labels. Call with (dict "ctx" . "component" "seller").
+*/}}
+{{- define "arc-nanopayments.componentSelectorLabels" -}}
+{{ include "arc-nanopayments.selectorLabels" .ctx }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Fully qualified container image reference.
+*/}}
+{{- define "arc-nanopayments.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+imagePullSecrets list (YAML), empty when none configured.
+*/}}
+{{- define "arc-nanopayments.imagePullSecrets" -}}
+{{- with .Values.image.pullSecrets }}
+{{- toYaml . -}}
+{{- end }}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "arc-nanopayments.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "arc-nanopayments.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Shared ExternalSecret / synced Secret name.
+*/}}
+{{- define "arc-nanopayments.externalSecretName" -}}
+{{- default (printf "%s-secrets" (include "arc-nanopayments.fullname" .)) .Values.externalSecret.target.name -}}
+{{- end -}}
+
+{{/*
+Seller Service DNS name (in-cluster), used to derive the buyer's BASE_URL.
+*/}}
+{{- define "arc-nanopayments.sellerBaseUrl" -}}
+{{- if .Values.buyer.baseUrl -}}
+{{- .Values.buyer.baseUrl -}}
+{{- else -}}
+{{- printf "http://%s-seller:%d" (include "arc-nanopayments.fullname" .) (int .Values.seller.service.port) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/templates/buyer/deployment.yaml
+++ b/deploy/helm/templates/buyer/deployment.yaml
@@ -1,0 +1,72 @@
+{{- $component := "buyer" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "arc-nanopayments.fullname" . }}-{{ $component }}
+  labels:
+    {{- include "arc-nanopayments.componentLabels" (dict "ctx" . "component" $component) | nindent 4 }}
+spec:
+  replicas: {{ .Values.buyer.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "arc-nanopayments.componentSelectorLabels" (dict "ctx" . "component" $component) | nindent 6 }}
+  strategy:
+    # The agent funds ephemeral wallets from a single funder key; avoid running two
+    # instances of the same generation concurrently during rollout.
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "arc-nanopayments.componentSelectorLabels" (dict "ctx" . "component" $component) | nindent 8 }}
+      {{- $ann := deepCopy (.Values.buyer.podAnnotations | default dict) }}
+      {{- with .Values.deployRevision }}{{- $_ := set $ann "arc-nanopayments/deploy-revision" . }}{{- end }}
+      {{- with $ann }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "arc-nanopayments.serviceAccountName" . }}
+      {{- $pullSecrets := include "arc-nanopayments.imagePullSecrets" . }}
+      {{- if $pullSecrets }}
+      imagePullSecrets:
+        {{- $pullSecrets | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ $component }}
+          image: {{ include "arc-nanopayments.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          # Run the payment agent. Use args (not command) so the image's tini
+          # ENTRYPOINT is preserved — tini stays PID 1 and forwards SIGTERM to
+          # node for a clean shutdown. No --limit: that flag triggers an
+          # interactive stdin prompt (promptForAllowance) that would hang in a pod.
+          args:
+            - node
+            - --experimental-transform-types
+            - --no-warnings
+            - agent.mts
+          envFrom:
+            - configMapRef:
+                name: {{ include "arc-nanopayments.fullname" . }}-config
+            {{- if .Values.externalSecret.enabled }}
+            - secretRef:
+                name: {{ include "arc-nanopayments.externalSecretName" . }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.buyer.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "arc-nanopayments.fullname" . }}-config
+  labels:
+    {{- include "arc-nanopayments.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  # Derived: the in-cluster seller URL the buyer agent targets.
+  BASE_URL: {{ include "arc-nanopayments.sellerBaseUrl" . | quote }}

--- a/deploy/helm/templates/external-secret.yaml
+++ b/deploy/helm/templates/external-secret.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.externalSecret.enabled -}}
+{{- $es := .Values.externalSecret -}}
+{{- if not (.Capabilities.APIVersions.Has (printf "%s/ExternalSecret" $es.apiVersion)) -}}
+{{- fail (printf "externalSecret.enabled=true but CRD %s/ExternalSecret is not installed. Install External Secrets Operator or set externalSecret.enabled=false." $es.apiVersion) -}}
+{{- end -}}
+apiVersion: {{ $es.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "arc-nanopayments.externalSecretName" . }}
+  labels:
+    {{- include "arc-nanopayments.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ $es.secretStoreRef.name }}
+    kind: {{ $es.secretStoreRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: {{ include "arc-nanopayments.externalSecretName" . }}
+    creationPolicy: Owner
+  {{- with $es.dataFrom }}
+  dataFrom:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $es.data }}
+  data:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/templates/seller/deployment.yaml
+++ b/deploy/helm/templates/seller/deployment.yaml
@@ -1,0 +1,78 @@
+{{- $component := "seller" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "arc-nanopayments.fullname" . }}-{{ $component }}
+  labels:
+    {{- include "arc-nanopayments.componentLabels" (dict "ctx" . "component" $component) | nindent 4 }}
+spec:
+  replicas: {{ .Values.seller.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "arc-nanopayments.componentSelectorLabels" (dict "ctx" . "component" $component) | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "arc-nanopayments.componentSelectorLabels" (dict "ctx" . "component" $component) | nindent 8 }}
+      {{- $ann := deepCopy (.Values.seller.podAnnotations | default dict) }}
+      {{- with .Values.deployRevision }}{{- $_ := set $ann "arc-nanopayments/deploy-revision" . }}{{- end }}
+      {{- with $ann }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "arc-nanopayments.serviceAccountName" . }}
+      {{- $pullSecrets := include "arc-nanopayments.imagePullSecrets" . }}
+      {{- if $pullSecrets }}
+      imagePullSecrets:
+        {{- $pullSecrets | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ $component }}
+          image: {{ include "arc-nanopayments.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          # CMD stays the image default: node server.js
+          ports:
+            - name: http
+              containerPort: {{ .Values.seller.containerPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "arc-nanopayments.fullname" . }}-config
+            {{- if .Values.externalSecret.enabled }}
+            - secretRef:
+                name: {{ include "arc-nanopayments.externalSecretName" . }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.seller.probePath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.seller.probePath }}
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.seller.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/templates/seller/healthcheckpolicy.yaml
+++ b/deploy/helm/templates/seller/healthcheckpolicy.yaml
@@ -1,0 +1,24 @@
+{{- /* GKE Gateway needs an explicit HealthCheckPolicy or the Cloud LB uses its
+   own default probe against the target Service. "/" returns 200 for the seller,
+   so the default works too, but this makes the check explicit and configurable.
+   Gated on the networking.gke.io CRD so non-GKE Gateway implementations
+   (Envoy Gateway, Contour, …) don't trip on a missing CRD. */ -}}
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.healthCheck.enabled (.Capabilities.APIVersions.Has "networking.gke.io/v1") -}}
+{{- $component := "seller" -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ include "arc-nanopayments.fullname" . }}-{{ $component }}
+  labels:
+    {{- include "arc-nanopayments.componentLabels" (dict "ctx" . "component" $component) | nindent 4 }}
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: {{ .Values.httpRoute.healthCheck.path | quote }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "arc-nanopayments.fullname" . }}-{{ $component }}
+{{- end -}}

--- a/deploy/helm/templates/seller/httproute.yaml
+++ b/deploy/helm/templates/seller/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $component := "seller" -}}
+{{- if not .Values.httpRoute.parentRefs -}}
+{{- fail "httpRoute.enabled=true requires httpRoute.parentRefs (reference an existing Gateway; the chart does not create one)" -}}
+{{- end -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "arc-nanopayments.fullname" . }}-{{ $component }}
+  labels:
+    {{- include "arc-nanopayments.componentLabels" (dict "ctx" . "component" $component) | nindent 4 }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range $path := .Values.httpRoute.pathPrefixes }}
+        - path:
+            type: PathPrefix
+            value: {{ $path | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ include "arc-nanopayments.fullname" . }}-{{ $component }}
+          port: {{ .Values.seller.service.port }}
+{{- end -}}

--- a/deploy/helm/templates/seller/service.yaml
+++ b/deploy/helm/templates/seller/service.yaml
@@ -1,0 +1,16 @@
+{{- $component := "seller" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "arc-nanopayments.fullname" . }}-{{ $component }}
+  labels:
+    {{- include "arc-nanopayments.componentLabels" (dict "ctx" . "component" $component) | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.seller.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "arc-nanopayments.componentSelectorLabels" (dict "ctx" . "component" $component) | nindent 4 }}

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "arc-nanopayments.serviceAccountName" . }}
+  labels:
+    {{- include "arc-nanopayments.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/values-dev.yaml
+++ b/deploy/helm/values-dev.yaml
@@ -1,0 +1,65 @@
+# Haia dev cluster (GKE) overlay for arc-nanopayments.
+#
+# Usage (CI deploys this automatically; the seller hostname + namespace are
+# injected from GitHub Actions variables — DEV_HOST / DEPLOY_NAMESPACE — so
+# they stay out of this public file). Run manually with:
+#   helm upgrade --install arc-nanopayments deploy/helm \
+#     -n <namespace> --create-namespace \
+#     -f deploy/helm/values-dev.yaml \
+#     --set httpRoute.hostnames[0]=<seller-host>
+#
+# Cluster-side prerequisites (must exist before deploy):
+#   - Gateway API CRDs (gateway.networking.k8s.io/v1) + the shared external
+#     Gateway `external-gateway` in the `infra` namespace, with a listener that
+#     admits routes for the dev domain from this namespace.
+#   - External Secrets Operator (external-secrets.io/v1) with a
+#     `gcp-secret-manager` ClusterSecretStore wired to the project.
+#   - A single GCP Secret Manager entry (JSON) with all app secrets:
+#       arc-dev-nanopayments -> { SUPABASE_SERVICE_ROLE_KEY, SELLER_PRIVATE_KEY, BUYER_PRIVATE_KEY }
+#   - DNS: the seller host -> the external Gateway's address.
+# (No image pull secret needed — the GHCR package is public.)
+
+image:
+  # CI publishes ghcr.io/haia-finance/arc-nanopayments:latest (mutable).
+  # Always re-pull so each rollout picks up the freshly pushed image.
+  tag: latest
+  pullPolicy: Always
+
+# Non-secret env. SUPABASE_SERVICE_ROLE_KEY / SELLER_PRIVATE_KEY / BUYER_PRIVATE_KEY
+# come from ESO (below); NEXT_PUBLIC_* are baked into the image at build time.
+config:
+  # seller wallet address (public, safe to commit).
+  SELLER_ADDRESS: "0x4c40F215A209F873aCd89226f40c1Db1A1B6553d"
+  # Faster demo cadence in dev (default is 600000 = 10 min).
+  PAYMENT_INTERVAL_MS: "60000"
+
+# ── Routing — GKE Gateway API ──────────────────────────────────────────────
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: external-gateway
+      namespace: infra
+  # Seller hostname is injected by CI from the DEV_HOST Actions variable
+  # (kept out of this public file). For manual installs pass:
+  #   --set httpRoute.hostnames[0]=<seller-host>
+  hostnames: []
+  pathPrefixes:
+    - /
+  healthCheck:
+    enabled: true
+    path: /
+
+# ── Secrets — GCP Secret Manager via External Secrets Operator ─────────────
+# One shared entry synced into one Secret, consumed by both roles.
+externalSecret:
+  enabled: true
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  refreshInterval: 15m
+  dataFrom:
+    - extract:
+        key: arc-dev-nanopayments
+
+# Keep registry/history churn low on dev.
+revisionHistoryLimit: 2

--- a/deploy/helm/values-dev.yaml
+++ b/deploy/helm/values-dev.yaml
@@ -30,8 +30,8 @@ image:
 config:
   # seller wallet address (public, safe to commit).
   SELLER_ADDRESS: "0x4c40F215A209F873aCd89226f40c1Db1A1B6553d"
-  # Faster demo cadence in dev (default is 600000 = 10 min).
-  PAYMENT_INTERVAL_MS: "60000"
+  # Payment cadence: 10 min (600000 ms).
+  PAYMENT_INTERVAL_MS: "600000"
 
 # ── Routing — GKE Gateway API ──────────────────────────────────────────────
 httpRoute:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,139 @@
+# Default values for arc-nanopayments.
+
+# -- Overrides for the generated chart/release name.
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  # -- Container registry host.
+  registry: ghcr.io
+  # -- Image repository (without registry host).
+  repository: haia-finance/arc-nanopayments
+  # -- Image tag. Empty string defaults to .Chart.AppVersion ("latest").
+  # Set to an immutable tag (e.g. a git SHA) for reliable rollouts.
+  tag: ""
+  # -- Image pull policy. "Always" is appropriate while tag is "latest".
+  pullPolicy: Always
+  # -- Image pull secrets. The GHCR package is public, so none are needed.
+  # If you make the package private, add e.g. `- name: ghcr-pull`.
+  pullSecrets: []
+
+serviceAccount:
+  # -- Create a ServiceAccount for the workloads.
+  create: true
+  # -- Annotations for the ServiceAccount (e.g. GKE Workload Identity binding).
+  annotations: {}
+  # -- Explicit name; empty uses the generated fullname.
+  name: ""
+
+# -- revisionHistoryLimit for both Deployments.
+revisionHistoryLimit: 3
+
+# -- Rollout marker stamped as a pod annotation on both Deployments. Set this
+# to a per-deploy value (e.g. the git SHA) so Helm rolls the pods even when the
+# image reference is unchanged (e.g. a mutable ":latest" tag with
+# pullPolicy: Always). Empty = no annotation.
+deployRevision: ""
+
+# -- Pod-level security context. uid/gid 1001 matches the image's `nextjs` user.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  fsGroup: 1001
+
+# -- Container-level security context.
+containerSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  allowPrivilegeEscalation: false
+  # Next.js standalone writes to .next/cache at runtime, so the root FS stays writable.
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+# -- Scheduling controls applied to every pod.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- Non-secret environment, rendered into a ConfigMap and shared by both roles.
+# Extra keys are harmless — each role ignores env it doesn't use.
+config:
+  NODE_ENV: production
+  # Seller wallet address (public). Fill this in.
+  SELLER_ADDRESS: ""
+  # Buyer knobs (agent.mts).
+  DEPOSIT_AMOUNT: "1"
+  PAYMENT_INTERVAL_MS: "600000"
+
+# ---- seller: the Next.js app (node server.js) ----
+seller:
+  replicas: 1
+  containerPort: 3000
+  service:
+    port: 3000
+  # HTTP path used for pod probes and the GKE LB health check.
+  probePath: "/"
+  podAnnotations: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+# ---- buyer: the payment agent (agent.mts) ----
+buyer:
+  replicas: 1
+  # BASE_URL the agent points at. Empty -> in-cluster seller Service.
+  baseUrl: ""
+  podAnnotations: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
+httpRoute:
+  # -- Expose the seller via a Gateway API HTTPRoute.
+  enabled: true
+  # -- Existing Gateway(s) to attach to. The chart does NOT create a Gateway;
+  # TLS/listeners live on that Gateway. REQUIRED when httpRoute.enabled.
+  parentRefs:
+    - name: ""           # e.g. the shared external Gateway name
+      # namespace: ""    # optional: Gateway namespace if different
+      # sectionName: ""  # optional: specific Gateway listener
+  # -- Public hostname(s) routed to the seller (e.g. ["arc.example.com"]).
+  hostnames: []
+  # -- Path prefixes routed to the seller.
+  pathPrefixes:
+    - /
+  healthCheck:
+    # -- GKE HealthCheckPolicy (networking.gke.io/v1) targeting the seller Service.
+    # Rendered only on clusters that have the GKE CRD.
+    enabled: true
+    # -- HTTP path the load balancer probes. "/" returns 200 for the seller.
+    path: /
+
+externalSecret:
+  # -- Sync app secrets from GCP Secret Manager via External Secrets Operator
+  # into a single Secret shared by both the seller and buyer pods.
+  enabled: true
+  apiVersion: external-secrets.io/v1
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  # -- Name of the synced K8s Secret; empty uses "<fullname>-secrets".
+  target:
+    name: ""
+  # `dataFrom.extract` pulls one JSON Secret Manager entry whose keys become the
+  # synced Secret's keys. Expected keys (consumed via envFrom by both roles):
+  #   SUPABASE_SERVICE_ROLE_KEY, SELLER_PRIVATE_KEY, BUYER_PRIVATE_KEY
+  # Use `data` instead for explicit per-key mapping (see reference chart).
+  dataFrom:
+    - extract:
+        key: arc-nanopayments
+  data: []

--- a/lib/x402.ts
+++ b/lib/x402.ts
@@ -16,177 +16,111 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BatchFacilitatorClient } from "@circle-fin/x402-batching/server";
+import { createGatewayMiddleware } from "@circle-fin/x402-batching/server";
 import { createClient } from "@supabase/supabase-js";
 import { NextRequest, NextResponse } from "next/server";
 
-// Arc Testnet contract addresses (from @circle-fin/x402-batching SDK)
 const ARC_TESTNET_NETWORK = "eip155:5042002";
-const ARC_TESTNET_USDC = "0x3600000000000000000000000000000000000000";
-const ARC_TESTNET_GATEWAY_WALLET = "0x0077777d7EBA4688BDeF3E311b846F25870A19B9";
+const TESTNET_FACILITATOR_URL = "https://gateway-api-testnet.circle.com";
 
 export const sellerAddress = process.env.SELLER_ADDRESS as `0x${string}`;
-
-const facilitator = new BatchFacilitatorClient();
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
-interface PaymentPayload {
-  x402Version: number;
-  resource?: { url: string; description: string; mimeType: string };
-  accepted?: Record<string, unknown>;
-  payload: Record<string, unknown>;
-  extensions?: Record<string, unknown>;
-}
+// Single middleware instance shared by every paywalled route. It fetches the
+// accepted networks / USDC addresses / verifying contract from the facilitator,
+// so the manual Arc-specific `extra` block is no longer hardcoded here.
+const gateway = createGatewayMiddleware({
+  sellerAddress,
+  networks: [ARC_TESTNET_NETWORK],
+  facilitatorUrl: TESTNET_FACILITATOR_URL,
+});
 
-function buildPaymentRequirements(price: string) {
-  // Parse dollar amount to USDC atomic units (6 decimals)
-  const amount = Math.round(parseFloat(price.replace("$", "")) * 1_000_000);
+// --- Lifecycle hooks: the integration surface for Haia Trace (HAD-336 phase 4).
+// verify/settle spans attach here. For now they persist the settled payment and
+// log; swap the bodies for Haia Trace spans once its SDK lands.
+gateway.onBeforeVerify(async (ctx) => {
+  console.log(`[haia-trace] verify start ${ctx.requirements.network}`);
+});
 
-  return {
-    scheme: "exact" as const,
-    network: ARC_TESTNET_NETWORK,
-    asset: ARC_TESTNET_USDC,
-    amount: amount.toString(),
-    payTo: sellerAddress,
-    maxTimeoutSeconds: 345600,
-    extra: {
-      name: "GatewayWalletBatched",
-      version: "1",
-      verifyingContract: ARC_TESTNET_GATEWAY_WALLET,
-    },
-  };
-}
+gateway.onAfterSettle(async (ctx) => {
+  const { requirements, result } = ctx;
+  const amountUsdc = (Number(requirements.amount) / 1e6).toString();
+  const payer = result.payer ?? "unknown";
+
+  const { error } = await supabase.from("payment_events").insert({
+    endpoint: ctx.paymentPayload.resource?.url ?? "unknown",
+    payer,
+    amount_usdc: amountUsdc,
+    network: requirements.network,
+    gateway_tx: result.transaction ?? null,
+    raw: { requirements, result },
+  });
+  if (error) {
+    console.error("Failed to record payment event:", error.message);
+  }
+  console.log(`[haia-trace] settled ${amountUsdc} USDC from ${payer}`);
+});
+
+gateway.onSettleFailure(async (ctx) => {
+  console.error(`[haia-trace] settle failed: ${ctx.error.message}`);
+});
 
 /**
- * Wraps a Next.js route handler with Circle Gateway payment verification.
- *
- * Follows fred-mvp's approach: manually constructs payment requirements with
- * the Gateway batching `extra` field and calls BatchFacilitatorClient directly.
+ * Adapts the SDK's Express-style Gateway middleware to a Next.js App Router
+ * handler. The middleware drives the full x402 lifecycle (402 challenge, verify,
+ * settle, hooks); `next()` bridges through to the actual route handler.
  */
 export function withGateway(
   handler: (req: NextRequest) => Promise<NextResponse>,
   price: string,
   endpoint: string,
 ) {
-  const requirements = buildPaymentRequirements(price);
+  const middleware = gateway.require(price);
 
-  return async (req: NextRequest) => {
-    const paymentSignature = req.headers.get("payment-signature");
+  return async (req: NextRequest): Promise<NextResponse> => {
+    const nodeReq = {
+      method: req.method,
+      // The `resource.url` echoed back to the buyer and used as the Supabase
+      // endpoint label comes from here.
+      url: endpoint,
+      headers: Object.fromEntries(req.headers),
+    } as Record<string, unknown>;
 
-    // No payment — return 402 with Gateway batching payment requirements
-    if (!paymentSignature) {
-      console.log(`[x402] 402 Payment Required: ${endpoint}`);
+    let status = 200;
+    const outHeaders = new Headers();
+    let outBody = "";
+    const nodeRes = {
+      statusCode: 200,
+      setHeader: (k: string, v: string) => outHeaders.set(k, v),
+      end: (b?: string) => {
+        outBody = b ?? "";
+      },
+    };
 
-      const paymentRequired = {
-        x402Version: 2,
-        resource: {
-          url: endpoint,
-          description: `Paid resource (${price} USDC)`,
-          mimeType: "application/json",
-        },
-        accepts: [requirements],
-      };
+    let handlerResponse: NextResponse | null = null;
+    const next = async () => {
+      handlerResponse = await handler(req);
+    };
 
-      return new NextResponse(JSON.stringify({}), {
-        status: 402,
-        headers: {
-          "Content-Type": "application/json",
-          "PAYMENT-REQUIRED": Buffer.from(
-            JSON.stringify(paymentRequired),
-          ).toString("base64"),
-        },
-      });
+    await (middleware as unknown as (
+      req: unknown,
+      res: unknown,
+      next: () => Promise<void>,
+    ) => Promise<void>)(nodeReq, nodeRes, next);
+    status = nodeRes.statusCode;
+
+    // Middleware ran the handler via next() — forward its response, merging the
+    // middleware-set PAYMENT-RESPONSE header.
+    if (handlerResponse) {
+      outHeaders.forEach((v, k) => handlerResponse!.headers.set(k, v));
+      return handlerResponse;
     }
 
-    // Payment present — verify and settle via Circle Gateway
-    try {
-      const paymentPayload: PaymentPayload = JSON.parse(
-        Buffer.from(paymentSignature, "base64").toString("utf-8"),
-      );
-
-      const verifyResult = await facilitator.verify(
-        paymentPayload,
-        requirements,
-      );
-
-      if (!verifyResult.isValid) {
-        return NextResponse.json(
-          {
-            error: "Payment verification failed",
-            reason: verifyResult.invalidReason,
-          },
-          { status: 402 },
-        );
-      }
-
-      const settleResult = await facilitator.settle(
-        paymentPayload,
-        requirements,
-      );
-
-      if (!settleResult.success) {
-        console.error(
-          `[x402] Settlement failed for ${endpoint}: ${settleResult.errorReason}`,
-        );
-        return NextResponse.json(
-          {
-            error: "Payment settlement failed",
-            reason: settleResult.errorReason,
-          },
-          { status: 402 },
-        );
-      }
-
-      // Record payment event in Supabase
-      const amountUsdc = (
-        Number(requirements.amount) / 1e6
-      ).toString();
-      const payer = settleResult.payer ?? verifyResult.payer ?? "unknown";
-
-      const { error } = await supabase.from("payment_events").insert({
-        endpoint,
-        payer,
-        amount_usdc: amountUsdc,
-        network: requirements.network,
-        gateway_tx: settleResult.transaction ?? null,
-        raw: { requirements, settleResult },
-      });
-
-      if (error) {
-        console.error("Failed to record payment event:", error.message);
-      }
-
-      console.log(
-        `[x402] Payment settled: ${endpoint} — ${amountUsdc} USDC from ${payer}`,
-      );
-
-      // Call the actual route handler
-      const response = await handler(req);
-
-      // Forward settlement info to the client
-      const settleResponseHeader = Buffer.from(
-        JSON.stringify({
-          success: true,
-          transaction: settleResult.transaction,
-          network: requirements.network,
-          payer,
-        }),
-      ).toString("base64");
-
-      response.headers.set("PAYMENT-RESPONSE", settleResponseHeader);
-      return response;
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : String(error);
-      console.error("[x402] Payment processing error:", message);
-      return NextResponse.json(
-        { error: "Payment processing error", message },
-        { status: 500 },
-      );
-    }
+    // Middleware short-circuited (402 challenge, verification/settlement error).
+    return new NextResponse(outBody, { status, headers: outHeaders });
   };
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,9 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   output: "standalone",
   outputFileTracingRoot: process.cwd(),
+  // Pin the workspace root: a stray lockfile in a parent dir (e.g. ~/package-lock.json)
+  // otherwise makes Turbopack infer the wrong root and mis-resolve node_modules.
+  turbopack: { root: process.cwd() },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  output: "standalone",
+  outputFileTracingRoot: process.cwd(),
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "arc-nanopayments-demo",
+  "name": "arc-nanopayments",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "@circle-fin/x402-batching": "^2.0.4",
+        "@circle-fin/x402-batching": "^3.2.0",
         "@langchain/core": "^1.1.32",
         "@langchain/openai": "^1.2.13",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -14,8 +14,8 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.0",
-        "@x402/core": "^2.6.0",
-        "@x402/evm": "^2.6.0",
+        "@x402/core": "^2.19.0",
+        "@x402/evm": "^2.19.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "deepagents": "^1.8.2",
@@ -43,11 +43,10 @@
       }
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT",
-      "peer": true
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -93,6 +92,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -329,9 +329,9 @@
       "license": "MIT"
     },
     "node_modules/@circle-fin/x402-batching": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@circle-fin/x402-batching/-/x402-batching-2.0.4.tgz",
-      "integrity": "sha512-q1rGOuFHyday0Rbc5V9PnNmoRotxGjc+CxqimjW+A0fjcdvYUi3Lnud/+94/KYqUqFLgOR9/5E2X41a1HxaA4g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@circle-fin/x402-batching/-/x402-batching-3.2.0.tgz",
+      "integrity": "sha512-ft+ynAsYIGGQNAeud8v73GKyg1qonycMVqEK8Gt+ATwtrNBikYhfMtO9l7zMZCOTA1hJ1NJOnGWBFUR/gvDHjw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -1159,6 +1159,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.32.tgz",
       "integrity": "sha512-ZZNiER5tceFXqZOghfrxNHzM60gcQL5XK/8Ow5+o4OuKHrP1p/RUQBDM9Y1nddi/VmKQj+ncaXXM5KovXTEGGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -1393,13 +1394,40 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3154,48 +3182,32 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@spruceid/siwe-parser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.1.2.tgz",
-      "integrity": "sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.3.0",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      }
-    },
-    "node_modules/@stablelib/binary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "license": "MIT",
       "dependencies": {
-        "@stablelib/int": "^1.0.1"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@stablelib/int": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/random": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
       "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@stablelib/wipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
-      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3284,6 +3296,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.0.tgz",
       "integrity": "sha512-SP9Sn9tsHDB7N4u2gT13rdeZJewE4xibAxasG7vOz+fYi92+XkMMbWNx0uGK53zKTnAnvTs16isRooyBy4sn5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.99.0",
         "@supabase/functions-js": "2.99.0",
@@ -3627,6 +3640,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3637,6 +3651,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3701,6 +3716,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -4308,38 +4324,24 @@
       ]
     },
     "node_modules/@x402/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-ISC/JeVss6xlKvor2rp18tJf9K5OQlIDDfZW1VZJQGDI2F4gy+HWxxkFfcQalCsPp4YUlwqh0YOkUxP+LTZWVg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.19.0.tgz",
+      "integrity": "sha512-IPQIHzIrwvbri1339QWHvwtiTTDbGsrF5Yff0LZfufmVXNdOSYbjY8oz6vZg7+4W13f7/k81NUMAFoDOU4gswQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "zod": "^3.24.2"
       }
     },
     "node_modules/@x402/evm": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.6.0.tgz",
-      "integrity": "sha512-wPkNHf483gie1Up2sJSvERnW+VIEvMoT1KRXr09wSoSWgelglsJm+ug3gPPXKnT3C6AcmNAKZ12rBnu9Paff7g==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.19.0.tgz",
+      "integrity": "sha512-ycbYCjJmLC1I7tRQslAwB73FhJAVMPzsojYunWuR5hk+jKUwgC6djch1ZrKFC1f9lJi7IOiezZtRHj6TWyCCrg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@x402/core": "~2.6.0",
-        "@x402/extensions": "~2.6.0",
-        "viem": "^2.39.3",
-        "zod": "^3.24.2"
-      }
-    },
-    "node_modules/@x402/extensions": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.6.0.tgz",
-      "integrity": "sha512-aLY9xAOOiRLKDN9HT2r9TYUXbD+IsoBces9qPZNVJGO2TBi2rfmbIBc3pcKCtWKn3iTvG2QFr3gpOFdpJRzqww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scure/base": "^1.2.6",
-        "@x402/core": "~2.6.0",
-        "ajv": "^8.17.1",
-        "siwe": "^2.3.2",
-        "tweetnacl": "^1.0.3",
-        "viem": "^2.43.5",
+        "@x402/core": "~2.19.0",
+        "viem": "^2.48.11",
         "zod": "^3.24.2"
       }
     },
@@ -4370,6 +4372,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4387,29 +4390,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -4421,12 +4401,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/apg-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
-      "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4752,6 +4726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5245,6 +5220,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -5563,6 +5539,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5773,6 +5750,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6089,107 +6067,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/ethers/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD",
-      "peer": true
-    },
-    "node_modules/ethers/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/ethers/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -6200,6 +6077,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -6243,22 +6121,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -7240,12 +7102,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8095,6 +7951,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.30",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -8293,6 +8179,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8441,6 +8328,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8450,6 +8338,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8575,15 +8464,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -8932,21 +8812,6 @@
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
       "license": "MIT"
     },
-    "node_modules/siwe": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.3.2.tgz",
-      "integrity": "sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@spruceid/siwe-parser": "^2.1.2",
-        "@stablelib/random": "^1.0.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
-      },
-      "peerDependencies": {
-        "ethers": "^5.6.8 || ^6.0.8"
-      }
-    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -9244,6 +9109,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9317,12 +9183,6 @@
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9421,6 +9281,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9548,6 +9409,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -9618,15 +9480,10 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
-    },
     "node_modules/viem": {
-      "version": "2.47.1",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.1.tgz",
-      "integrity": "sha512-frlK109+X5z2vlZeIGKa6Rxev6CcIpumV/VVhaIPc/QFotiB6t/CgUwkMlYfr4F2YNBZZ2l6jguWz2sY1XrQHw==",
+      "version": "2.55.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.4.tgz",
+      "integrity": "sha512-iSVcFADHPS0GRcY+YMGubuOH0QXcLN87HVlPNaFLPzJv6OzNOql2cim+QxtTe/QxXUqbXLnzTmpFms4PLGyJ6A==",
       "funding": [
         {
           "type": "github",
@@ -9634,6 +9491,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -9641,137 +9499,14 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.0",
-        "ws": "8.18.3"
+        "ox": "0.14.30",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/viem/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
-    },
-    "node_modules/viem/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/@scure/bip32": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
-      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.0",
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/@scure/bip39": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
-      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/ox": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.0.tgz",
-      "integrity": "sha512-WLOB7IKnmI3Ol6RAqY7CJdZKl8QaI44LN91OGF1061YIeN6bL5IsFcdp7+oQShRyamE/8fW/CBRWhJAOzI35Dw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }
@@ -9892,10 +9627,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9952,6 +9688,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "agent": "node --experimental-transform-types --no-warnings --env-file=.env.local agent.mts"
   },
   "dependencies": {
-    "@circle-fin/x402-batching": "^2.0.4",
+    "@circle-fin/x402-batching": "^3.2.0",
     "@langchain/core": "^1.1.32",
     "@langchain/openai": "^1.2.13",
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -18,8 +18,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.0",
-    "@x402/core": "^2.6.0",
-    "@x402/evm": "^2.6.0",
+    "@x402/core": "^2.19.0",
+    "@x402/evm": "^2.19.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "deepagents": "^1.8.2",


### PR DESCRIPTION
## Summary
- Add `@usehaia/trace-x402` + `@usehaia/trace-core` (0.0.3) and attach `trace()` on both sides of the payment: the Gateway middleware in `lib/x402.ts` (duck-typed as x402 `httpResourceServer`, all 8 hooks) and `GatewayClient` in `agent.mts` (`client`, 4 hooks)
- Remove the placeholder `[haia-trace]` console hooks they were reserved for; Supabase persistence in `onAfterSettle` stays as-is
- Run files land in `.trace/events/` (hardcoded, gitignored); capture is passive and can never alter the payment flow

## Test plan
- `npm run build`, `npx tsc --noEmit`, `npm run lint` — clean
- E2E happy path: 10 payments — full chains on both sides (`payment.creating → submitted → responded` / `verify.started → verify.ok → settle.started → settle.ok`), buyer and seller resolve the same payment to the same `context_id`, payloads redacted
- E2E failure paths: forged signature → `x402.verify.failed`; underfunded Gateway balance → 17× `x402.settle.failed` (`insufficient_balance`) + `x402.payment.canceled`, client maps them to `x402.verify.failed` per adapter docs